### PR TITLE
Remove "js" language indicator from code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you go directly to the URL `/wp-json/wp/v2/users` you will get a `401 Unautho
 
 But if you open a block editor page and run the following from the browser console,
 
-```js
+```
 await wp.apiFetch({path: 'wp/v2/users'});
 ```
 


### PR DESCRIPTION
Remove "js" language indicator from code block in markdown for wordpress.org compatiblity.

Resolves #2